### PR TITLE
fix(ci): scope concurrency group to workflow+ref

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,7 +24,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: "pages"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -186,7 +186,8 @@ jobs:
   # ---------------------------------------------------------
   deploy:
     name: Deploy to GitHub Pages
-    # Only deploy if the build stage succeeds
+    # Only deploy if the build stage succeeds, and only on pushes to main (not PRs)
+    if: github.event_name == 'push'
     needs: build
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- Scoped the concurrency group from the hardcoded `"pages"` to `${{ github.workflow }}-${{ github.ref }}` so each branch/PR gets its own slot
- Prevents Renovate PRs from cancelling in-flight push-to-main deployments
- Within the same PR, `cancel-in-progress: true` still applies so only the latest commit runs

## Test plan

- [ ] Open a Renovate PR and verify the main branch pipeline is not cancelled
- [ ] Verify multiple Renovate PRs run independently
- [ ] Verify `cancel-in-progress` still works within a single PR on re-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)