### PR TITLE
chore: exclude .claude/ from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ package-lock.json
 !.vscode/extensions.json
 !.vscode/tasks.json
 
+# Claude Code
+.claude/
+
 # Misc
 _sass/vendors
 assets/js/dist


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` to keep local Claude Code configuration (settings, CLAUDE.md) out of the repository

## Test plan

- [ ] Verify `.claude/` is not tracked after merge