### PR TITLE
Update fraud posts with June 2026 outcomes

### DIFF
--- a/_posts/2026-04-24-session-hijacked-bank-account-drained.md
+++ b/_posts/2026-04-24-session-hijacked-bank-account-drained.md
@@ -179,7 +179,9 @@ As of publishing: I'm still waiting on both. Eleven days into the Anthropic case
 
 My bank contacted Anthropic's bank directly to attempt a recovery. That route also came up empty — the funds could not be retrieved through the interbank process.
 
-> **€341.12 still outstanding.** Anthropic support unresponsive after 6+ weeks. Interbank recovery attempted and failed. If you're in the same position, document everything and keep escalating — both through Anthropic's support and your bank's dispute process.
+A complaint has also been filed with the **Autoriteit Persoonsgegevens (AP)** regarding the handling of personal data and the security failures that enabled this incident.
+
+> **€341.12 still outstanding.** Anthropic support unresponsive after 6+ weeks. Interbank recovery attempted and failed. AP complaint filed. If you're in the same position, document everything and escalate on all fronts — Anthropic support, your bank's dispute process, and the AP.
 {: .prompt-warning }
 
 ---

--- a/_posts/2026-04-24-session-hijacked-bank-account-drained.md
+++ b/_posts/2026-04-24-session-hijacked-bank-account-drained.md
@@ -171,6 +171,17 @@ As of publishing: I'm still waiting on both. Eleven days into the Anthropic case
 
 ---
 
+## Update — June 2026
+
+**Klarna (separate incident, April 28):** Resolved. After multiple rounds of formal disputes, Klarna closed the case in my favour — they were unable to produce any evidence that the transactions were mine. Both charges written off. Full account in [Klarna Identity Theft: How the 'Klarna Method' Exploits Stolen Data](/posts/klarna-psn-gift-card-fraud).
+
+**Anthropic:** The original case has been open since April 24 — now over six weeks — with no resolution and no money back. I've opened a second case because the first has gone silent. No human response yet on either.
+
+> **€341.12 still outstanding.** If you're in the same position — Anthropic case open, no response — consider escalating via your bank's chargeback process in parallel. Don't wait on Anthropic's support queue.
+{: .prompt-warning }
+
+---
+
 ## What You Should Do Right Now
 
 ### If you use Claude Code on a VPS or remote server

--- a/_posts/2026-04-24-session-hijacked-bank-account-drained.md
+++ b/_posts/2026-04-24-session-hijacked-bank-account-drained.md
@@ -177,7 +177,9 @@ As of publishing: I'm still waiting on both. Eleven days into the Anthropic case
 
 **Anthropic:** The original case has been open since April 24 — now over six weeks — with no resolution and no money back. I've opened a second case because the first has gone silent. No human response yet on either.
 
-> **€341.12 still outstanding.** If you're in the same position — Anthropic case open, no response — consider escalating via your bank's chargeback process in parallel. Don't wait on Anthropic's support queue.
+My bank contacted Anthropic's bank directly to attempt a recovery. That route also came up empty — the funds could not be retrieved through the interbank process.
+
+> **€341.12 still outstanding.** Anthropic support unresponsive after 6+ weeks. Interbank recovery attempted and failed. If you're in the same position, document everything and keep escalating — both through Anthropic's support and your bank's dispute process.
 {: .prompt-warning }
 
 ---

--- a/_posts/2026-04-28-klarna-psn-gift-card-fraud.md
+++ b/_posts/2026-04-28-klarna-psn-gift-card-fraud.md
@@ -72,7 +72,18 @@ Klarna can bypass SCA using a [**Transaction Risk Analysis (TRA)** exemption](ht
 
 ---
 
-*This incident and the [April 17 Claude session hijack](/posts/session-hijacked-bank-account-drained) are covered under a single police report filed with a cybercrime specialist. Whether both incidents share a common origin is unknown. Updates will follow as the Klarna dispute progresses.*
+*This incident and the [April 17 Claude session hijack](/posts/session-hijacked-bank-account-drained) are covered under a single police report filed with a cybercrime specialist. Whether both incidents share a common origin is unknown.*
+
+---
+
+## Update — June 2026
+
+After multiple rounds of correspondence and formal disputes, **Klarna closed the case in my favour**. They were unable to provide any evidence linking the transactions to me — no matching device fingerprint, no IP address, nothing that held up under scrutiny. Both charges of €77.75 were written off.
+
+The outcome is consistent with what the activity log already showed: no authentication event before the purchases, no login, no device recognition that could plausibly be mine. When pushed to actually produce the evidence behind their initial rejection, they couldn't.
+
+> If Klarna rejects your fraud report citing "recognized device" — push back. Request the technical evidence in writing. IP address, device fingerprint, timestamp. If they can't produce it, or if the data doesn't match your devices or network, you have grounds for a successful appeal.
+{: .prompt-tip }
 
 ---
 


### PR DESCRIPTION
## Summary

- **Klarna post**: Added update — Klarna closed the case in favour, charges written off after failing to produce evidence
- **Session hijack post**: Added update — Anthropic case open 6+ weeks with no resolution, second case opened, interbank recovery attempted and failed, €341.12 still outstanding

## Changes

- `_posts/2026-04-28-klarna-psn-gift-card-fraud.md` — new Update section with resolution
- `_posts/2026-04-24-session-hijacked-bank-account-drained.md` — new Update section with current Anthropic case status and failed interbank recovery

https://claude.ai/code/session_011JsNSGxXu6JLcjD8SR9Mwf

---
_Generated by [Claude Code](https://claude.ai/code/session_011JsNSGxXu6JLcjD8SR9Mwf)_