### PR TITLE
fix: correct regulatory body from AP to ACM

### DIFF
--- a/_posts/2026-04-24-session-hijacked-bank-account-drained.md
+++ b/_posts/2026-04-24-session-hijacked-bank-account-drained.md
@@ -179,9 +179,9 @@ As of publishing: I'm still waiting on both. Eleven days into the Anthropic case
 
 My bank contacted Anthropic's bank directly to attempt a recovery. That route also came up empty — the funds could not be retrieved through the interbank process.
 
-A complaint has also been filed with the **Autoriteit Persoonsgegevens (AP)** regarding the handling of personal data and the security failures that enabled this incident.
+A complaint has also been filed with the **Autoriteit Consument & Markt (ACM)** regarding the handling of this incident.
 
-> **€341.12 still outstanding.** Anthropic support unresponsive after 6+ weeks. Interbank recovery attempted and failed. AP complaint filed. If you're in the same position, document everything and escalate on all fronts — Anthropic support, your bank's dispute process, and the AP.
+> **€341.12 still outstanding.** Anthropic support unresponsive after 6+ weeks. Interbank recovery attempted and failed. ACM complaint filed. If you're in the same position, document everything and escalate on all fronts — Anthropic support, your bank's dispute process, and the ACM.
 {: .prompt-warning }
 
 ---


### PR DESCRIPTION
Corrects the regulatory body mentioned in the session hijack post update from AP (Autoriteit Persoonsgegevens) to ACM (Autoriteit Consument & Markt).

https://claude.ai/code/session_011JsNSGxXu6JLcjD8SR9Mwf

---
_Generated by [Claude Code](https://claude.ai/code/session_011JsNSGxXu6JLcjD8SR9Mwf)_